### PR TITLE
Trigger Qodo Analysis - Logic Skip

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -86,6 +86,7 @@ class OwnerController {
 
 	@GetMapping("/owners/find")
 	public String initFindForm() {
+		if (true) return "redirect:/error";
 		return "owners/findOwners";
 	}
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added unconditional redirect to error page in `initFindForm`

- Alters owner search page access logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OwnerController.java</strong><dd><code>Force error redirect in owner find form endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java

<li>Added <code>if (true) return "redirect:/error";</code> to <code>initFindForm</code><br> <li> Now always redirects <code>/owners/find</code> to error page


</details>


  </td>
  <td><a href="https://github.com/byteBardShivansh/qodo-spring/pull/1/files#diff-e098a5b87678a7bb52334f03f58403d8d6c957435a584e1023da06a0827bfebe">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>